### PR TITLE
Change 'links' dictionary keys

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ class Main(KytosNApp):
         """
         links = []
         for link in self.topology.links:
-            links.append({'source': link[0], 'target': link[1]})
+            links.append({'a': link[0], 'b': link[1]})
 
         return jsonify({'links': links})
 


### PR DESCRIPTION
Change from source/target to a/b, to match the topology export.
Fix #33