### PR TITLE
Fixed undefined link NameError

### DIFF
--- a/main.py
+++ b/main.py
@@ -128,7 +128,7 @@ class Main(KytosNApp):
             return jsonify("Switch not found"), 404
 
         switch.remove_metadata(key)
-        self.notify_metadata_changes(switch,'removed')
+        self.notify_metadata_changes(switch, 'removed')
         return jsonify("Operation successful"), 200
 
     # Interface related methods
@@ -293,7 +293,7 @@ class Main(KytosNApp):
     def delete_link_metadata(self, link_id, key):
         """Delete metadata from a link."""
         try:
-            status = self.links[link_id]
+            link = self.links[link_id]
         except KeyError:
             return jsonify("Link not found"), 404
 
@@ -371,7 +371,7 @@ class Main(KytosNApp):
         if interface.link:
             interface.link.activate()
         self.notify_topology_update()
-        self.update_instance_metadata(link)
+        self.update_instance_metadata(interface.link)
 
     @listen_to('.*.switch.interface.link_down')
     def handle_interface_link_down(self, event):


### PR DESCRIPTION
Hi @macartur, I was testing on mininet as usual, and as soon as I had a link up condition I got this traceback:

```
2018-06-19 07:50:27,756 - INFO [kytos/of_core] (Thread-73) Connection ('127.0.0.1', 39254), Switch 00:00:00:00:00:00:00:01: OPENFLOW HANDSHAKE COMPLETE
2018-06-19 07:50:27,766 - INFO [kytos/of_core] (Thread-74) Connection ('127.0.0.1', 39256), Switch 00:00:00:00:00:00:00:02: OPENFLOW HANDSHAKE COMPLETE
2018-06-19 07:50:27,775 - INFO [atcp_server] (MainThread) New connection from 127.0.0.1:39258
2018-06-19 07:50:27,776 - INFO [controller] (MainThread) Handling kytos/core.connection.new...
Exception in thread Thread-88:
Traceback (most recent call last):
  File "/usr/lib64/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib64/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/home/viniarck/repos/kytos/kytos/core/helpers.py", line 72, in threaded_handler
    handler(*args)
  File "/home/viniarck/repos/kytos/.direnv/python-3.6.5/var/lib/kytos/napps/kytos/topology/main.py", line 374, in handle_interface_link_up
    self.update_instance_metadata(link)
NameError: name 'link' is not defined

```

I've tested the same condition with this PR and I don't see the error anymore. Can you review this PR?

Thanks!