### PR TITLE
Solving issue running integration and unit tests together

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ class Linter(SimpleCommand):
     def run(self):
         """Run yala."""
         print('Yala is running. It may take several seconds...')
-        check_call('yala *.py tests/integration/*.py', shell=True)
+        check_call('yala *.py tests', shell=True)
 
 
 class CITest(SimpleCommand):

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -114,6 +114,11 @@ class TestMain(TestCase):
         Set the server_name_url from kytos/topology
         """
         self.server_name_url = 'http://localhost:8181/api/kytos/topology'
+
+        patch('kytos.core.helpers.run_on_thread', lambda x: x).start()
+        from napps.kytos.topology.main import Main
+        self.addCleanup(patch.stopall)
+        self.napp = Main(get_controller_mock())
         self.init_napp()
 
     @patch('napps.kytos.topology.main.Main.verify_storehouse')


### PR DESCRIPTION
Today, running integration and unit tests together, some tests are stopped.This commit solves that problem.

Related: https://github.com/kytos/topology/issues/92