### PR TITLE
Save and restore the administrative status for Links

### DIFF
--- a/main.py
+++ b/main.py
@@ -137,19 +137,19 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         """Load network status saved in storehouse."""
         status = self.storehouse.get_data()
         if status:
-            switches = status.get('network_status')['switches']
-            links = status.get('network_status')['links']
+            switches = status['network_status']['switches']
+            links = status['network_status']['links']
             # get link status
             for link, link_attributes in links.items():
-                self.links_state[link] = link_attributes.get('enabled')
+                self.links_state[link] = link_attributes['enabled']
 
             for switch, switch_attributes in switches.items():
                 # get swicthes status
-                self.switches_state[switch] = switch_attributes.get('enabled')
+                self.switches_state[switch] = switch_attributes['enabled']
                 interfaces = switch_attributes['interfaces']
                 # get interface status
                 for interface, interface_attributes in interfaces.items():
-                    enabled_value = interface_attributes.get('enabled')
+                    enabled_value = interface_attributes['enabled']
                     lldp_value = interface_attributes['lldp']
                     self.interfaces_state[interface] = (enabled_value,
                                                         lldp_value)

--- a/main.py
+++ b/main.py
@@ -28,6 +28,9 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         """Initialize the NApp's links list."""
         self.links = {}
         self.store_items = {}
+        self.switches_state = {}
+        self.interfaces_state = {}
+        self.links_state = {}
         self.link_up_timer = getattr(settings, 'LINK_UP_TIMER',
                                      DEFAULT_LINK_UP_TIMER)
 
@@ -88,10 +91,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 return link
         return None
 
-    def _restore_status(self, switches_status, interfaces_status):
+    def _restore_status(self):
         """Restore the network administrative status saved in StoreHouse."""
         # restore Switches
-        for switch_id, state in switches_status.items():
+        for switch_id, state in self.switches_state.items():
             try:
                 if state:
                     self.controller.switches[switch_id].enable()
@@ -102,7 +105,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                          f'{switch_id} does not exist.')
                 raise KeyError(error)
         # restore interfaces
-        for interface_id, state in interfaces_status.items():
+        for interface_id, state in self.interfaces_state.items():
             switch_id = ":".join(interface_id.split(":")[:-1])
             interface_number = int(interface_id.split(":")[-1])
             interface_status, lldp_status = state
@@ -117,31 +120,44 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 error = ('Error while restoring interface status. The '
                          f'interface {interface_id} does not exist.')
                 raise KeyError(error)
-
+        # links
+        for link, state, in self.links_state.items():
+            try:
+                if state:
+                    self.links[link].enable()
+                else:
+                    self.links[link].disable()
+            except KeyError:
+                error = ('Error restoring link status.'
+                         f'The link {link} does not exist.')
+                raise KeyError(error)
         log.info('Network status restored.')
 
     def _load_network_status(self):
         """Load network status saved in storehouse."""
-        switches_status = {}
-        interfaces_status = {}
         status = self.storehouse.get_data()
-        if not status:
+        if status:
+            switches = status.get('network_status')['switches']
+            links = status.get('network_status')['links']
+            # get link status
+            for link, link_attributes in links.items():
+                self.links_state[link] = link_attributes.get('enabled')
+
+            for switch, switch_attributes in switches.items():
+                # get swicthes status
+                self.switches_state[switch] = switch_attributes.get('enabled')
+                interfaces = switch_attributes['interfaces']
+                # get interface status
+                for interface, interface_attributes in interfaces.items():
+                    enabled_value = interface_attributes.get('enabled')
+                    lldp_value = interface_attributes['lldp']
+                    self.interfaces_state[interface] = (enabled_value,
+                                                        lldp_value)
+
+        else:
             error = 'There is no status saved to restore.'
             log.info(error)
             raise FileNotFoundError(error)
-
-        switches = status['network_status']['switches']
-        for switch, switch_attributes in switches.items():
-            # get status the switches
-            switches_status[switch] = switch_attributes['enabled']
-            interfaces = switch_attributes['interfaces']
-            # get status the interfaces and lldp
-            for interface, interface_attributes in interfaces.items():
-                enabled_value = interface_attributes['enabled']
-                lldp_value = interface_attributes['lldp']
-                interfaces_status[interface] = (enabled_value, lldp_value)
-
-        return switches_status, interfaces_status
 
     @rest('v3/')
     def get_topology(self):
@@ -155,8 +171,8 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     def restore_network_status(self):
         """Restore the network administrative status saved in StoreHouse."""
         try:
-            switches_status, interfaces_status = self._load_network_status()
-            self._restore_status(switches_status, interfaces_status)
+            self._load_network_status()
+            self._restore_status()
         except (KeyError, FileNotFoundError) as exc:
             return jsonify(f'{str(exc)}'), 404
 
@@ -374,7 +390,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             self.links[link_id].enable()
         except KeyError:
             return jsonify("Link not found"), 404
-
+        self.save_status_on_storehouse()
         return jsonify("Operation successful"), 201
 
     @rest('v3/links/<link_id>/disable', methods=['POST'])
@@ -384,7 +400,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             self.links[link_id].disable()
         except KeyError:
             return jsonify("Link not found"), 404
-
+        self.save_status_on_storehouse()
         return jsonify("Operation successful"), 201
 
     @rest('v3/links/<link_id>/metadata')
@@ -600,6 +616,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                      f" {content['attribute']} attribute to"
                      f" {content['state']} in the interfaces"
                      f" {content['interface_ids']}")
+        status.update(self._get_links_dict())
         self.storehouse.save_status(status)
 
     def notify_topology_update(self):


### PR DESCRIPTION
Today, changes in the Link administrative status (enabled/disabled) are not stored
in the storehouse NApp. This commit solves this problem, ensuring persistence
for these modifications.

The restored of the saved data must be triggered manually using this REST Endpoint:

`GET http://0.0.0.0:8181/api/kytos/topology/v3/restore`

Fix https://github.com/kytos/topology/issues/119