### PR TITLE
Update Link creation to handle exception

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import time
 from flask import jsonify, request
 
 from kytos.core import KytosEvent, KytosNApp, log, rest
+from kytos.core.exceptions import KytosLinkCreationError
 from kytos.core.helpers import listen_to
 from kytos.core.interface import Interface
 from kytos.core.link import Link
@@ -601,14 +602,18 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         interface_a = event.content['interface_a']
         interface_b = event.content['interface_b']
 
-        link = self._get_link_or_create(interface_a, interface_b)
-        interface_a.update_link(link)
-        interface_b.update_link(link)
+        try:
+            link = self._get_link_or_create(interface_a, interface_b)
+        except KytosLinkCreationError as err:
+            log.error(f'Error on creating link: {err}.')
+        else:
+            interface_a.update_link(link)
+            interface_b.update_link(link)
 
-        interface_a.nni = True
-        interface_b.nni = True
+            interface_a.nni = True
+            interface_b.nni = True
 
-        self.notify_topology_update()
+            self.notify_topology_update()
 
     # def add_host(self, event):
     #    """Update the topology with a new Host."""

--- a/main.py
+++ b/main.py
@@ -605,15 +605,16 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         try:
             link = self._get_link_or_create(interface_a, interface_b)
         except KytosLinkCreationError as err:
-            log.error(f'Error on creating link: {err}.')
-        else:
-            interface_a.update_link(link)
-            interface_b.update_link(link)
+            log.error(f'Error creating link: {err}.')
+            return
 
-            interface_a.nni = True
-            interface_b.nni = True
+        interface_a.update_link(link)
+        interface_b.update_link(link)
 
-            self.notify_topology_update()
+        interface_a.nni = True
+        interface_b.nni = True
+
+        self.notify_topology_update()
 
     # def add_host(self, event):
     #    """Update the topology with a new Host."""


### PR DESCRIPTION
Today, an error occurs when the method _get_link_or_create is called with an empty endpoint. This commit changes this method, handling this exception and returning None when an exception is raised. In addition, this commit changes the method add_links to return if the link does not exist. 

Fix kytos/topology#110