### PR TITLE
Add events to notify that Switch was enabled/disabled

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,25 +7,25 @@
 -e git+https://github.com/kytos/kytos.git#egg=kytos
 -e .
 -e git+https://github.com/kytos/python-openflow.git#egg=python-openflow
-astroid==2.0.4            # via pylint
-click==6.7                # via pip-tools
+astroid==2.3.3            # via pylint
+click==7.1.1              # via pip-tools
 coverage==5.0.3
 docopt==0.6.2             # via yala
 first==2.0.1              # via pip-tools
 isort==4.3.4              # via pylint, yala
-lazy-object-proxy==1.3.1  # via astroid
+lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
-pip-tools==2.0.2
-pluggy==0.7.1             # via tox
-py==1.6.0                 # via tox
-pycodestyle==2.4.0        # via yala
-pydocstyle==2.1.1         # via yala
-pylint==2.1.1             # via yala
+pip-tools==4.5.1
+pluggy==0.13.1            # via tox
+py==1.8.0                 # via tox
+pycodestyle==2.5.0        # via yala
+pydocstyle==5.1.1         # via yala
+pylint==2.4.4             # via yala
 pytest==5.4.1             # via pytest
-six==1.11.0               # via astroid, pip-tools, pydocstyle, tox
+six==1.15.0               # via astroid, pip-tools, pydocstyle, tox
 snowballstemmer==1.2.1    # via pydocstyle
 tox==3.2.1
-typed-ast==1.1.0          # via astroid
-virtualenv==16.0.0        # via tox
-wrapt==1.10.11            # via astroid
-yala==1.7.0
+typed-ast==1.4.0          # via astroid
+virtualenv==20.0.15        # via tox
+wrapt==1.11.2            # via astroid
+yala==2.2.0

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -104,7 +104,7 @@ class FakeBox:
         self.owner = None
 
 
-# pylint: disable=bad-option-value
+# pylint: disable=import-outside-toplevel
 class TestMain(TestCase):
     """Test the Main class."""
 

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,8 +1,8 @@
 """Module to help to create tests."""
 from unittest.mock import Mock
 
-from kytos.core.config import KytosConfig
 from kytos.core import Controller
+from kytos.core.config import KytosConfig
 
 
 def get_controller_mock():

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,19 +1,16 @@
 """Module to test the main napp file."""
-import time
 import json
-
+import time
 from unittest import TestCase
 from unittest.mock import MagicMock, create_autospec, patch
 
-from kytos.core.switch import Switch
 from kytos.core.interface import Interface
 from kytos.core.link import Link
-from kytos.lib.helpers import (get_switch_mock, get_interface_mock,
-                               get_test_client, get_link_mock)
-
-
-from tests.unit.helpers import get_controller_mock, get_napp_urls
+from kytos.core.switch import Switch
+from kytos.lib.helpers import (get_interface_mock, get_link_mock,
+                               get_switch_mock, get_test_client)
 from napps.kytos.topology.exceptions import RestoreError
+from tests.unit.helpers import get_controller_mock, get_napp_urls
 
 
 # pylint: disable=too-many-public-methods
@@ -30,6 +27,7 @@ class TestMain(TestCase):
         self.server_name_url = 'http://localhost:8181/api/kytos/topology'
 
         patch('kytos.core.helpers.run_on_thread', lambda x: x).start()
+        # pylint: disable=import-outside-toplevel
         from napps.kytos.topology.main import Main
         self.addCleanup(patch.stopall)
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -862,6 +862,26 @@ class TestMain(TestCase):
 
     @patch('napps.kytos.topology.main.KytosEvent')
     @patch('kytos.core.buffers.KytosEventBuffer.put')
+    def test_notify_switch_enabled(self, *args):
+        """Test notify switch enabled."""
+        dpid = "00:00:00:00:00:00:00:01"
+        (mock_buffers_put, mock_event) = args
+        self.napp.notify_switch_enabled(dpid)
+        mock_event.assert_called()
+        mock_buffers_put.assert_called()
+
+    @patch('napps.kytos.topology.main.KytosEvent')
+    @patch('kytos.core.buffers.KytosEventBuffer.put')
+    def test_notify_switch_disabled(self, *args):
+        """Test notify switch disabled."""
+        dpid = "00:00:00:00:00:00:00:01"
+        (mock_buffers_put, mock_event) = args
+        self.napp.notify_switch_disabled(dpid)
+        mock_event.assert_called()
+        mock_buffers_put.assert_called()
+
+    @patch('napps.kytos.topology.main.KytosEvent')
+    @patch('kytos.core.buffers.KytosEventBuffer.put')
     def test_notify_topology_update(self, *args):
         """Test notify_topology_update."""
         (mock_buffers_put, mock_event) = args

--- a/tests/unit/test_storehouse.py
+++ b/tests/unit/test_storehouse.py
@@ -1,6 +1,6 @@
 """Module to test the storehouse client."""
 from unittest import TestCase
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
 from tests.unit.helpers import get_controller_mock
 
@@ -18,6 +18,7 @@ class TestStoreHouse(TestCase):
         self.server_name_url = 'http://localhost:8181/api/kytos/topology'
 
         patch('kytos.core.helpers.run_on_thread', lambda x: x).start()
+        # pylint: disable=import-outside-toplevel
         from napps.kytos.topology.storehouse import StoreHouse
         self.addCleanup(patch.stopall)
 


### PR DESCRIPTION
### :octocat: Are you working on some issue? Identify the issue!

Fix https://github.com/kytos/topology/issues/143

### :bookmark_tabs: Description of the Change

Created events to notify when a ``switch`` were administratively enabled/disabled.

### :computer: Verification Process

- Running tests

### :page_facing_up: Release Notes

-  New events to notify when a ``switch`` were administratively enabled/disabled.
