### PR TITLE
Added input validation to metadata sent using REST endpoints

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ Manage the network topology
 import time
 
 from flask import jsonify, request
+from werkzeug.exceptions import BadRequest
 
 from kytos.core import KytosEvent, KytosNApp, log, rest
 from kytos.core.exceptions import KytosLinkCreationError
@@ -280,7 +281,14 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     @rest('v3/switches/<dpid>/metadata', methods=['POST'])
     def add_switch_metadata(self, dpid):
         """Add metadata to a switch."""
-        metadata = request.get_json()
+        try:
+            metadata = request.get_json()
+        except BadRequest:
+            return jsonify('The request body is not a well-formed JSON.'), 400
+        if metadata is None:
+            return jsonify('The request body mimetype is not'
+                           ' application/json.'), 400
+
         try:
             switch = self.controller.switches[dpid]
         except KeyError:
@@ -394,7 +402,13 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     @rest('v3/interfaces/<interface_id>/metadata', methods=['POST'])
     def add_interface_metadata(self, interface_id):
         """Add metadata to an interface."""
-        metadata = request.get_json()
+        try:
+            metadata = request.get_json()
+        except BadRequest:
+            return jsonify('The request body is not a well-formed JSON.'), 400
+        if metadata is None:
+            return jsonify('The request body mimetype is not'
+                           ' application/json.'), 400
 
         switch_id = ":".join(interface_id.split(":")[:-1])
         interface_number = int(interface_id.split(":")[-1])
@@ -474,7 +488,14 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     @rest('v3/links/<link_id>/metadata', methods=['POST'])
     def add_link_metadata(self, link_id):
         """Add metadata to a link."""
-        metadata = request.get_json()
+        try:
+            metadata = request.get_json()
+        except BadRequest:
+            return jsonify('The request body is not a well-formed JSON.'), 400
+        if metadata is None:
+            return jsonify('The request body mimetype is not'
+                           ' application/json.'), 400
+
         try:
             link = self.links[link_id]
         except KeyError:
@@ -827,7 +848,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             all_metadata = self.store_items.get('links', None)
             if all_metadata:
                 metadata = all_metadata.data.get(obj.id)
-
         if metadata:
             obj.extend_metadata(metadata)
             log.debug(f'Metadata to {obj.id} was updated')

--- a/main.py
+++ b/main.py
@@ -61,11 +61,16 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         """Return a JSON with metadata."""
         try:
             metadata = request.get_json()
+            content_type = request.content_type
         except BadRequest:
             result = 'The request body is not a well-formed JSON.'
             raise BadRequest(result)
+        if content_type is None:
+            result = ('The request body is empty.')
+            raise BadRequest(result)
         if metadata is None:
-            result = 'The content type must be application/json.'
+            result = ('The content type must be application/json and not '
+                      f'{content_type}.')
             raise UnsupportedMediaType(result)
         return metadata
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -407,6 +407,21 @@ class TestMain(TestCase):
                             content_type='application/json')
         self.assertEqual(response.status_code, 404, response.data)
 
+    def test_add_switch_metadata_wrong_format(self):
+        """Test add_switch_metadata_wrong_format."""
+        dpid = "00:00:00:00:00:00:00:01"
+        api = get_test_client(self.napp.controller, self.napp)
+        payload = 'A'
+
+        url = f'{self.server_name_url}/v3/switches/{dpid}/metadata'
+        response = api.post(url, data=payload, content_type='application/json')
+        self.assertEqual(response.status_code, 400, response.data)
+
+        payload = None
+        response = api.post(url, data=json.dumps(payload),
+                            content_type='application/json')
+        self.assertEqual(response.status_code, 400, response.data)
+
     @patch('napps.kytos.topology.main.Main.notify_metadata_changes')
     def test_delete_switch_metadata(self, mock_metadata_changes):
         """Test delete_switch_metadata."""
@@ -579,6 +594,21 @@ class TestMain(TestCase):
                             content_type='application/json')
         self.assertEqual(response.status_code, 404, response.data)
 
+    def test_add_interface_metadata_wrong_format(self):
+        """Test add_interface_metadata_wrong_format."""
+        dpid = "00:00:00:00:00:00:00:01:1"
+        api = get_test_client(self.napp.controller, self.napp)
+        payload = 'A'
+
+        url = f'{self.server_name_url}/v3/interfaces/{dpid}/metadata'
+        response = api.post(url, data=payload, content_type='application/json')
+        self.assertEqual(response.status_code, 400, response.data)
+
+        payload = None
+        response = api.post(url, data=json.dumps(payload),
+                            content_type='application/json')
+        self.assertEqual(response.status_code, 400, response.data)
+
     def test_delete_interface_metadata(self):
         """Test delete_interface_metadata."""
         interface_id = '00:00:00:00:00:00:00:01:1'
@@ -701,6 +731,22 @@ class TestMain(TestCase):
         response = api.post(url, data=json.dumps(payload),
                             content_type='application/json')
         self.assertEqual(response.status_code, 404, response.data)
+
+    def test_add_link_metadata_wrong_format(self):
+        """Test add_link_metadata_wrong_format."""
+        link_id = 'cf0f4071be426b3f745027f5d22'
+        api = get_test_client(self.napp.controller, self.napp)
+        payload = "A"
+
+        url = f'{self.server_name_url}/v3/links/{link_id}/metadata'
+        response = api.post(url, data=payload,
+                            content_type='application/json')
+        self.assertEqual(response.status_code, 400, response.data)
+
+        payload = None
+        response = api.post(url, data=json.dumps(payload),
+                            content_type='application/json')
+        self.assertEqual(response.status_code, 400, response.data)
 
     @patch('napps.kytos.topology.main.Main.notify_metadata_changes')
     def test_delete_link_metadata(self, mock_metadata_changes):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -420,7 +420,7 @@ class TestMain(TestCase):
         payload = None
         response = api.post(url, data=json.dumps(payload),
                             content_type='application/json')
-        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(response.status_code, 415, response.data)
 
     @patch('napps.kytos.topology.main.Main.notify_metadata_changes')
     def test_delete_switch_metadata(self, mock_metadata_changes):
@@ -607,7 +607,7 @@ class TestMain(TestCase):
         payload = None
         response = api.post(url, data=json.dumps(payload),
                             content_type='application/json')
-        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(response.status_code, 415, response.data)
 
     def test_delete_interface_metadata(self):
         """Test delete_interface_metadata."""
@@ -746,7 +746,7 @@ class TestMain(TestCase):
         payload = None
         response = api.post(url, data=json.dumps(payload),
                             content_type='application/json')
-        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(response.status_code, 415, response.data)
 
     @patch('napps.kytos.topology.main.Main.notify_metadata_changes')
     def test_delete_link_metadata(self, mock_metadata_changes):


### PR DESCRIPTION
### :octocat: Are you working on some issue? Identify the issue!

Fix #144 


### :bookmark_tabs: Description of the Change

Add input validation to metadata sent in the payload at REST endpoints,
 this modification avoids broken related to wrong format.

### :computer: Verification Process

- Unit tests performed and verified manually.

### :page_facing_up: Release Notes

- Add input validation to metadata
